### PR TITLE
Templated Rectangle

### DIFF
--- a/src/display/DisplayEngine.cpp
+++ b/src/display/DisplayEngine.cpp
@@ -149,8 +149,8 @@ DISPLAY_ENGINE_STATUS DisplayEngine::setTextureClips()
 
 // THE drawTextureAt FUNCTIONS NEED TO BE REFACTORED
 DISPLAY_ENGINE_STATUS DisplayEngine::drawTextureAt(SDL_Texture* texture,
-                                                   const Rectangle& clipQuad,
-                                                   const Rectangle& drawQuad)
+                                                   const DisplayRectangle& clipQuad,
+                                                   const DisplayRectangle& drawQuad)
 {
     try {
         SDL_Rect t1 = {static_cast<int>(clipQuad.position.x),
@@ -183,8 +183,8 @@ DISPLAY_ENGINE_STATUS DisplayEngine::drawTextureAt(SDL_Texture* texture,
 
 // THE drawTextureAt FUNCTIONS NEED TO BE REFACTORED
 DISPLAY_ENGINE_STATUS DisplayEngine::drawTextureAt(const std::string& sheetName,
-                                                   const Rectangle& clipQuad,
-                                                   const Rectangle& drawQuad)
+                                                   const DisplayRectangle& clipQuad,
+                                                   const DisplayRectangle& drawQuad)
 {
     try {
         SDL_Rect t1 = {static_cast<int>(clipQuad.position.x),
@@ -216,8 +216,8 @@ DISPLAY_ENGINE_STATUS DisplayEngine::drawTextureAt(const std::string& sheetName,
 }
 
 DISPLAY_ENGINE_STATUS DisplayEngine::drawSpriteAt(const std::string& sheetName,
-                                                  const Rectangle& clipQuad,
-                                                  const Rectangle& drawQuad)
+                                                  const DisplayRectangle& clipQuad,
+                                                  const DisplayRectangle& drawQuad)
 {
     try {
         SDL_Texture* sheetCopy =
@@ -248,7 +248,7 @@ DISPLAY_ENGINE_STATUS DisplayEngine::drawSpriteAt(const std::string& sheetName,
     }
 }
 
-DISPLAY_ENGINE_STATUS DisplayEngine::drawRectangle(const Rectangle& rect,
+DISPLAY_ENGINE_STATUS DisplayEngine::drawRectangle(const DisplayRectangle& rect,
                                                    const std::string& colour)
 {
     if (rect.isUnconstrained()) { return DISPLAY_ENGINE_STATUS::ENGINE_SUCCESS; }

--- a/src/display/DisplayEngine.hpp
+++ b/src/display/DisplayEngine.hpp
@@ -21,6 +21,7 @@ using namespace orgmath;
 
 using Sprite = SDL_Surface;
 using HardwareTexture = SDL_Texture*;
+using DisplayRectangle = Rectangle<int>;
 
 enum class ImageBufferType { TEXTURE, SURFACE };
 
@@ -60,19 +61,19 @@ class DisplayEngine {
 
     /// Draws the clipQuad subset of texture at drawQuad.
     DISPLAY_ENGINE_STATUS drawTextureAt(SDL_Texture* texture,
-                                        const Rectangle& clipQuad,
-                                        const Rectangle& drawQuad);
+                                        const DisplayRectangle& clipQuad,
+                                        const DisplayRectangle& drawQuad);
 
     DISPLAY_ENGINE_STATUS drawTextureAt(const std::string& textureSheet,
-                                        const Rectangle& clipQuad,
-                                        const Rectangle& drawQuad);
+                                        const DisplayRectangle& clipQuad,
+                                        const DisplayRectangle& drawQuad);
 
     DISPLAY_ENGINE_STATUS drawSpriteAt(const std::string& spriteSheet,
-                                       const Rectangle& clipQuad,
-                                       const Rectangle& drawQuad);
+                                       const DisplayRectangle& clipQuad,
+                                       const DisplayRectangle& drawQuad);
 
     /// Draws a filled-in rectangle `rect` in colour `colour`
-    DISPLAY_ENGINE_STATUS drawRectangle(const Rectangle& rect,
+    DISPLAY_ENGINE_STATUS drawRectangle(const DisplayRectangle& rect,
                                         const std::string& colour = "red");
 
     /// Copies the content of a region of a stored sprite sheet to `out`.

--- a/src/display/Texture.cpp
+++ b/src/display/Texture.cpp
@@ -75,10 +75,13 @@ void Texture::setColor(Uint8 red, Uint8 green, Uint8 blue)
     SDL_SetTextureColorMod(_texture, red, green, blue);
 }
 
-void Texture::render(const int x, const int y, const Rectangle& clip)
+void Texture::render(const int x, const int y, const Rectangle<int>& clip)
 {
     // Set rendering space and render to screen
-    Rectangle renderQuad = {x, y, _width, _height};
+    Rectangle<int> renderQuad = {x,
+                                 y,
+                                 static_cast<float>(_width),
+                                 static_cast<float>(_height)};
 
     // Set clip rendering dimensions
     if (!clip.isNull()) {

--- a/src/display/Texture.cpp
+++ b/src/display/Texture.cpp
@@ -78,10 +78,7 @@ void Texture::setColor(Uint8 red, Uint8 green, Uint8 blue)
 void Texture::render(const int x, const int y, const Rectangle<int>& clip)
 {
     // Set rendering space and render to screen
-    Rectangle<int> renderQuad = {x,
-                                 y,
-                                 static_cast<float>(_width),
-                                 static_cast<float>(_height)};
+    Rectangle<int> renderQuad = {x, y, _width, _height};
 
     // Set clip rendering dimensions
     if (!clip.isNull()) {

--- a/src/display/Texture.hpp
+++ b/src/display/Texture.hpp
@@ -12,6 +12,8 @@ extern DisplayEngine displayEngine;
 
 using namespace orgmath;
 
+using DisplayRectangle = Rectangle<int>;
+
 class Texture {
   public:
     /// Initializes variables
@@ -37,7 +39,7 @@ class Texture {
     void setAlpha (Uint8 alpha);
 
     /// Renders texture at given point
-    void render(const int x, const int y, const Rectangle& clip);
+    void render(const int x, const int y, const DisplayRectangle& clip);
 
     /// Gets image dimensions
     void setWidth(int width) { _width = width; }

--- a/src/display/TexturedEntity.cpp
+++ b/src/display/TexturedEntity.cpp
@@ -11,10 +11,10 @@ void TexturedEntity::render(bool debug_worldPosition, bool debug_hitboxes)
     if (_spriteClip.isNull()) {
         return;
     }
-    Rectangle drawQuad = Rectangle(static_cast<int>(_position.x),
-                                   static_cast<int>(_position.y),
-                                   static_cast<int>(_width),
-                                   static_cast<int>(_height));
+    DisplayRectangle drawQuad = DisplayRectangle(static_cast<int>(_position.x),
+                                                 static_cast<int>(_position.y),
+                                                 static_cast<int>(_width),
+                                                 static_cast<int>(_height));
     displayEngine.drawTextureAt(_textureSheet, _spriteClip, drawQuad);
 
     if (debug_worldPosition) {
@@ -38,13 +38,19 @@ void TexturedEntity::render(bool debug_worldPosition, bool debug_hitboxes)
 
     if (debug_hitboxes) {
         for (const auto& hitbox : _hitboxes) {
-            Rectangle worldPosHitbox = relativeToWorldPos(hitbox);
-            displayEngine.drawRectangle(worldPosHitbox);
+            //TODO: Build a cleaner means of casting between different Rectangle types.
+            auto worldPosHitbox = relativeToWorldPos(hitbox);
+            auto displayPositionHitbox = Rectangle<int>(static_cast<int>(worldPosHitbox.position.x),
+                                                        static_cast<int>(worldPosHitbox.position.y),
+                                                        static_cast<int>(worldPosHitbox.width),
+                                                        static_cast<int>(worldPosHitbox.height));
+            displayEngine.drawRectangle(displayPositionHitbox);
         }
     }
 }
 
-void TexturedEntity::setTextureFromSpriteSheet(const std::string& sheetName, const Rectangle& spriteClip)
+void TexturedEntity::setTextureFromSpriteSheet(const std::string& sheetName,
+                                               const DisplayRectangle& spriteClip)
 {
     _textureSheet = sheetName;
     _spriteClip = spriteClip;
@@ -52,11 +58,11 @@ void TexturedEntity::setTextureFromSpriteSheet(const std::string& sheetName, con
 
 void TexturedEntity::createTextureFromSpriteSheet(const std::string& sheetName)
 {
-    _spriteClip = Rectangle(0, 0, 0, 0);
+    _spriteClip = DisplayRectangle(0, 0, 0, 0);
     _texture.loadFromSheet(sheetName);
 }
 
-void TexturedEntity::updateSprite(const Rectangle& spriteClip)
+void TexturedEntity::updateSprite(const DisplayRectangle& spriteClip)
 {
     _spriteClip = spriteClip;
 }

--- a/src/display/TexturedEntity.hpp
+++ b/src/display/TexturedEntity.hpp
@@ -23,10 +23,10 @@ class TexturedEntity : public Entity {
 
     /// Share a surface owned by the display engine.
     void setTextureFromSpriteSheet(const std::string& sheetName,
-                                   const Rectangle& spriteClip);
+                                   const DisplayRectangle& spriteClip);
 
     /// Sets a new sprite clip, changing the sprite displayed for the entity.
-    void updateSprite(const Rectangle& spriteClip);
+    void updateSprite(const DisplayRectangle& spriteClip);
 
     void createTextureFromSpriteSheet(const std::string& sheetName);
 
@@ -36,5 +36,5 @@ class TexturedEntity : public Entity {
   protected:
     std::string _textureSheet{};
     Texture _texture;
-    Rectangle _spriteClip;
+    DisplayRectangle _spriteClip;
 };

--- a/src/entities/Entity.cpp
+++ b/src/entities/Entity.cpp
@@ -15,12 +15,12 @@ std::string Entity::getStatus() const
     return status;
 }
 
-Rectangle Entity::relativeToWorldPos(const Rectangle& rect)
+Rectangle<float> Entity::relativeToWorldPos(const Rectangle<float>& rect)
 {
-    return Rectangle(int(_position.x + rect.position.x - rect.width / 2),
-                     int(_position.y + rect.position.y - rect.height / 2),
-                     int(rect.width),
-                     int(rect.height));
+    return Rectangle<float>(int(_position.x + rect.position.x - rect.width / 2),
+                            int(_position.y + rect.position.y - rect.height / 2),
+                            int(rect.width),
+                            int(rect.height));
 }
 
 Entity::~Entity() {}

--- a/src/entities/Entity.hpp
+++ b/src/entities/Entity.hpp
@@ -30,14 +30,14 @@ class Entity {
 
     void setHeight(float height) { _height = height; }
 
-    Rectangle relativeToWorldPos(const Rectangle& rect);
+    Rectangle<float> relativeToWorldPos(const Rectangle<float>& rect);
 
-    Rectangle temp_getHitbox() {
+    Rectangle<float> temp_getHitbox() {
         auto hb = _hitboxes.front();
-        return Rectangle(hb.position.x + _position.x - hb.width / 2,
-                         hb.position.y + _position.y - hb.height / 2,
-                         hb.width,
-                         hb.height);
+        return Rectangle<float>(hb.position.x + _position.x - hb.width / 2,
+                                hb.position.y + _position.y - hb.height / 2,
+                                hb.width,
+                                hb.height);
     }
 
     std::string getStatus() const;
@@ -47,6 +47,6 @@ class Entity {
     float _width;
     float _height;
 
-    std::vector<Rectangle> _hitboxes{};
+    std::vector<Rectangle<float>> _hitboxes{};
 
 };

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -6,7 +6,6 @@ set(HEADERS
 
 set(SOURCES
     Geometry.cpp
-    Vectors.cpp
     )
 
 source_group("Headers" FILES ${HEADERS})

--- a/src/math/Geometry.cpp
+++ b/src/math/Geometry.cpp
@@ -1,5 +1,12 @@
 #include "Geometry.hpp"
 
+using namespace orgmath;
+
+template class Point<int>;
+template class Point<float>;
+template class Rectangle<int>;
+template class Rectangle<float>;
+
 template <typename __type__>
 bool operator== (const orgmath::Rectangle<__type__>& r1,
                  const orgmath::Rectangle<__type__>& r2)

--- a/src/math/Geometry.cpp
+++ b/src/math/Geometry.cpp
@@ -1,49 +1,21 @@
 #include "Geometry.hpp"
 
-bool operator== (const orgmath::Rectangle& r1, const orgmath::Rectangle& r2) {
+template <typename __type__>
+bool operator== (const orgmath::Rectangle<__type__>& r1,
+                 const orgmath::Rectangle<__type__>& r2)
+{
     return ((r1.position.x == r2.position.x)
              && (r1.position.y == r2.position.y)
              && (r1.width == r2.width)
              && (r1.height == r2.height));
 }
 
-bool operator!= (const orgmath::Rectangle& r1, const orgmath::Rectangle& r2) {
+template <typename __type__>
+bool operator!= (const orgmath::Rectangle<__type__>& r1,
+                 const orgmath::Rectangle<__type__>& r2)
+{
     return ((r1.position.x != r2.position.x)
              || (r1.position.y != r2.position.y)
              || (r1.width != r2.width)
              || (r1.height != r2.height));
 }
-
-namespace orgmath {
-
-Rectangle::Rectangle(float x, float y, float w, float h)
-: width{w}
-, height{h}
-, position{x, y}
-{
-
-}
-
-Rectangle::Rectangle(float w, float h)
-: width{w}
-, height{h}
-{
-
-}
-
-bool Rectangle::isSquare() const
-{
-    return (width == height);
-}
-
-bool Rectangle::isNull() const
-{
-    return (position.isNull() && width == 0 && height == 0);
-}
-
-bool Rectangle::isUnconstrained() const
-{
-    return (position.x == nanf("") && position.y == nanf(""));
-}
-
-}; // namespace orgmath

--- a/src/math/Geometry.hpp
+++ b/src/math/Geometry.hpp
@@ -6,7 +6,6 @@
 namespace orgmath {
 
 /// Point
-
 struct Point {
     float x = 0;
     float y = 0;
@@ -24,49 +23,65 @@ constexpr Point ORIGIN{0, 0};
 
 
 /// Rectangle
-
+template <typename __type__>
 class Rectangle {
 public:
     Rectangle() = default;
 
     /// Instantiate a rectangle at a specific point.
-    Rectangle(float x, float y, float width, float height);
+    Rectangle(__type__ x, __type__ y, __type__ width, __type__ height)
+    : width{width}
+    , height{height}
+    , position{x, y}
+    {
+        // Void
+    }
 
     /// Instantiate a rectangle with topLeft point, width, and height.
-    Rectangle(Point topLeft, float width, float height);
+    Rectangle(Point topLeft, __type__ width, __type__ height);
 
     /// Instantiate a rectangle drawn from point topLeft to point bottomRight.
     Rectangle(Point topLeft, Point bottomRight);
 
     /// Instantiate an unconstrained rectangle.
-    Rectangle(float width, float height);
+    Rectangle(__type__ width, __type__ height)
+    : width{width}
+    , height{height}
+    {
+        // Void
+    }
 
     /// Returns true if 'this' has square dimensions.
-    bool isSquare() const;
+    bool isSquare() const
+    {
+        return (width == height);
+    }
 
     /// Returns true if 'this' has zero width, height, x, and y.
-    bool isNull() const;
+    bool isNull() const
+    {
+        return (position.isNull() && width == 0 && height == 0);
+    }
 
     /// Returns true if 'this' has an unspecified position (x and y = NaN/Inf).
-    bool isUnconstrained() const;
+    bool isUnconstrained() const
+    {
+        return (position.x == nanf("") && position.y == nanf(""));
+    }
 
     /// Return a string representation of the rectangle.
     /// An unconstrained rectangle should look like
     /// "{Inf, Inf, <width>, <height>}".
     std::string toString() const;
 
-    float width = 0;
-    float height = 0;
+    __type__ width = 0;
+    __type__ height = 0;
 
     // Position of the top-left corner of the rectangle.
     Point position{nanf(""), nanf("")};
 }; // Rectangle
 
-const Rectangle NULL_RECTANGLE{0, 0, 0, 0};
-
-
 /// Circle
-
 class Circle {
 public:
     /// Instantiate a cirlce with an x coordinate, y coordinate, and radius.
@@ -86,7 +101,10 @@ private:
 
 }; // namespace orgmath
 
+template <typename __type__>
+bool operator== (const orgmath::Rectangle<__type__>& r1,
+                 const orgmath::Rectangle<__type__>& r2);
 
-bool operator== (const orgmath::Rectangle& r1, const orgmath::Rectangle& r2);
-
-bool operator!= (const orgmath::Rectangle& r1, const orgmath::Rectangle& r2);
+template <typename __type__>
+bool operator!= (const orgmath::Rectangle<__type__>& r1,
+                 const orgmath::Rectangle<__type__>& r2);

--- a/src/math/Geometry.hpp
+++ b/src/math/Geometry.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
-#include "Window.hpp"
+#include "platform.hpp"
 #include "Vectors.hpp"
 
 namespace orgmath {
 
 /// Point
+template <typename __type__>
 struct Point {
-    float x = 0;
-    float y = 0;
+    __type__ x = 0;
+    __type__ y = 0;
 
     bool isNull() const {
         return (x == 0 && y == 0);
@@ -18,9 +19,6 @@ struct Point {
         return ("{" + std::to_string(x) + ", " + std::to_string(y) + "}");
     }
 }; // Point
-
-constexpr Point ORIGIN{0, 0};
-
 
 /// Rectangle
 template <typename __type__>
@@ -38,10 +36,10 @@ public:
     }
 
     /// Instantiate a rectangle with topLeft point, width, and height.
-    Rectangle(Point topLeft, __type__ width, __type__ height);
+    Rectangle(Point<__type__> topLeft, __type__ width, __type__ height);
 
     /// Instantiate a rectangle drawn from point topLeft to point bottomRight.
-    Rectangle(Point topLeft, Point bottomRight);
+    Rectangle(Point<__type__> topLeft, Point<__type__> bottomRight);
 
     /// Instantiate an unconstrained rectangle.
     Rectangle(__type__ width, __type__ height)
@@ -74,29 +72,31 @@ public:
     /// "{Inf, Inf, <width>, <height>}".
     std::string toString() const;
 
-    __type__ width = 0;
-    __type__ height = 0;
+    __type__ width{};
+    __type__ height{};
 
     // Position of the top-left corner of the rectangle.
-    Point position{nanf(""), nanf("")};
+    //TODO: Readd support for initializing position as a pair of NaNs.
+    Point<__type__> position{{}, {}};
 }; // Rectangle
 
 /// Circle
+template<typename __type__>
 class Circle {
 public:
     /// Instantiate a cirlce with an x coordinate, y coordinate, and radius.
-    Circle(float x, float y, float radius);
+    Circle(__type__ x, __type__ y, __type__ radius);
 
     /// Instantiate a circle with a center-point and radius.
-    Circle(Point centerPoint, float radius);
+    Circle(Point<__type__> centerPoint, __type__ radius);
 
     /// Instantiate an unconstrained circle.
-    Circle(float radius);
+    Circle(__type__ radius);
 
 private:
-    Point _center;
-    float _radius = 0;
-    float _circumference = 0;
+    Point<__type__> _center;
+    __type__ _radius = 0;
+    __type__ _circumference = 0;
 }; // Circle
 
 }; // namespace orgmath

--- a/src/physics/CollisionDetection.cpp
+++ b/src/physics/CollisionDetection.cpp
@@ -2,7 +2,7 @@
 
 namespace orgphysics {
 
-bool collisionDetected(const Rectangle& recA, const Rectangle& recB)
+bool collisionDetected(const Rectangle<float>& recA, const Rectangle<float>& recB)
 {
     if (recA.position.x < recB.position.x + recB.width
      && recA.position.x + recA.width > recB.position.x

--- a/src/physics/CollisionDetection.hpp
+++ b/src/physics/CollisionDetection.hpp
@@ -7,6 +7,6 @@ using namespace orgmath;
 
 namespace orgphysics {
 
-bool collisionDetected(const Rectangle& recA, const Rectangle& recB);
+bool collisionDetected(const Rectangle<float>& recA, const Rectangle<float>& recB);
 
 }; // namespace orgphysics


### PR DESCRIPTION
Previously the Rectangle class only supported float members. This hindered the performance of the structure in many situations where there were it was only required to handle ints.