### PR TITLE
Adding support for polygon-based collision detection

### DIFF
--- a/src/Collider.hpp
+++ b/src/Collider.hpp
@@ -17,7 +17,7 @@ class Collider {
     Vector2 _pendingPosition{};
     float _width;
     float _height;
-    double _angle = 0;
+    float _angle = 0;
 
     bool _movementPending = false;
     bool _collisionDetected = false;

--- a/src/CollisionDetection.cpp
+++ b/src/CollisionDetection.cpp
@@ -1,8 +1,12 @@
 #include "CollisionDetection.hpp"
 
+#include <limits>
+
 namespace orgphysics {
 
-bool collisionDetected(const Rectangle<float>& recA, const Rectangle<float>& recB)
+// Basic rectangle collision detection.
+bool collisionDetected(const Rectangle<float>& recA,
+                       const Rectangle<float>& recB)
 {
     if (recA.position.x < recB.position.x + recB.width
      && recA.position.x + recA.width > recB.position.x
@@ -12,46 +16,68 @@ bool collisionDetected(const Rectangle<float>& recA, const Rectangle<float>& rec
     }
 
     return false;
-    /*
-    bool xOverlap = false;
-    bool yOverlap = false;
+}
 
-    //TODO: Consider a check for unconstrained rects then return false.
-    if (recB.width == 0) {
-        // Only concerned with yOverlap
-    }
-
-    if (recB.height == 0) {
-        // Only concerned with xOverlap
-    }
-
-
-    if (recA.position.x < recB.position.x) {
-        if (recA.width <= 0) {
-            return false;
-        } else if (recA.position.x + recA.width > recB.position.x) {
-            xOverlap = true;
-        }
-    } else if (recB.position.x + recB.width > recA.position.x) {
-        xOverlap = true;
-    } else {
+// Generic polygon-based collision detection.
+// This function employs the Separating Axis Theorem
+bool collisionDetected(const PolygonCollider& colliderA,
+                       const PolygonCollider& colliderB)
+{
+    // Check if any axis on A separates the polygons.
+    if (separatedByAxis(colliderA, colliderB)) {
         return false;
     }
 
-    if (recA.position.y < recB.position.y) {
-        if (recA.height <= 0) {
-            return false;
-        } else if (recA.position.y + recA.height > recB.position.y) {
-            yOverlap = true;
-        }
-    } else if (recB.position.y + recB.height > recA.position.y) {
-        yOverlap = true;
-    } else {
+    // Check if any axis on B separates the polygons.
+    if (separatedByAxis(colliderB, colliderA)) {
         return false;
     }
 
-    return xOverlap && yOverlap;
-    */
+    // No separators were found, therefore a collision has occurred.
+    return true;
+}
+
+// Performs separating axis theorem (SAT). Returns true if the
+// polygons are separated by any axis on colliderA, and false otherwise.
+bool separatedByAxis(const PolygonCollider& colliderA,
+                     const PolygonCollider& colliderB)
+{
+    auto verticesA = colliderA.vertices;
+    auto verticesB = colliderB.vertices;
+    for (int a = 0; a < verticesA.size(); a++) {
+        // Get the adjacent point (modulo to wrap around in case we're at the end of the vector.)
+        int b = (a + 1) % verticesA.size();
+
+        // Calculate normal to the a->b edge for projection.
+        Vector2 projectionAxis = {-1 * (verticesA[b].y - verticesA[a].y),
+                                  verticesA[b].x - verticesA[a].x};
+
+        // Initialize max/min values.
+        float minA = std::numeric_limits<float>::infinity();
+        float maxA = -1 * std::numeric_limits<float>::infinity();
+
+        // Project all points onto the axis using dot product.
+        for (const auto& v : verticesA) {
+            float projectedV = (v.x * projectionAxis.x) + (v.y * projectionAxis.y);
+            minA = std::min(minA, projectedV);
+            maxA = std::max(maxA, projectedV);
+        }
+
+        // Now do the same projection of points for colliderB.
+        float minB = std::numeric_limits<float>::infinity();
+        float maxB = -1 * std::numeric_limits<float>::infinity();
+        for (const auto& v : verticesB) {
+            float projectedV = (v.x * projectionAxis.x) + (v.y * projectionAxis.y);
+            minB = std::min(minB, projectedV);
+            maxB = std::max(maxB, projectedV);
+        }
+
+        // Check if projections of the two polygons overlap.
+        // If they don't overlap, return true as we've found a separator.
+        if (!(maxB >= minA && maxA >= minB)) return true;
+    }
+
+    return false;
 }
 
 }; // namespace orgphysics

--- a/src/CollisionDetection.hpp
+++ b/src/CollisionDetection.hpp
@@ -1,11 +1,21 @@
 #pragma once
 
+#include <vector>
+
 #include "Geometry.hpp"
+#include "PolygonCollider.hpp"
 
 using namespace orgmath;
 
 namespace orgphysics {
 
-bool collisionDetected(const Rectangle<float>& recA, const Rectangle<float>& recB);
+bool collisionDetected(const Rectangle<float>& recA,
+                       const Rectangle<float>& recB);
+
+bool collisionDetected(const PolygonCollider& colliderA,
+                       const PolygonCollider& colliderB);
+
+bool separatedByAxis(const PolygonCollider& colliderA,
+                     const PolygonCollider& colliderB);
 
 }; // namespace orgphysics

--- a/src/DisplayEngine.cpp
+++ b/src/DisplayEngine.cpp
@@ -294,35 +294,19 @@ DISPLAY_ENGINE_STATUS DisplayEngine::drawRectangle(const DisplayRectangle& rect,
 // Draw arbitrary polygon.
 DISPLAY_ENGINE_STATUS DisplayEngine::drawPolygon(const std::vector<Vector2> vertices)
 {
-    Vector2 firstVertex = Vector2::nullVector();
-    Vector2 storedVertex = Vector2::nullVector();
-
     // Set drawing colour to red.
     SDL_SetRenderDrawColor(renderer, 0xFF, 0x00, 0x00, 0x77);
 
-    // Iterate between vertices while drawing points between them.
-    for (const auto& vertex : vertices) {
-        // Store the first vertex so that we can close the shape later.
-        if (storedVertex.isNull) {
-            firstVertex  = vertex;
-            storedVertex = vertex;
-            continue;
-        }
-
+    // Iterate through vertices while drawing points between them.
+    auto numVertices = vertices.size();
+    for (int i = 0; i < numVertices; i++)
+    {
         SDL_RenderDrawLine(renderer,
-                           storedVertex.x,
-                           storedVertex.y,
-                           vertex.x,
-                           vertex.y);
-        storedVertex = vertex;
+                           vertices[i].x,
+                           vertices[i].y,
+                           vertices[(i+1) % numVertices].x,
+                           vertices[(i+1) % numVertices].y);
     }
-
-    // Close the polygon.
-    SDL_RenderDrawLine(renderer,
-                       storedVertex.x,
-                       storedVertex.y,
-                       firstVertex.x,
-                       firstVertex.y);
 }
 
 

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -5,6 +5,7 @@
 #include "SDL.h"
 #include "Vectors.hpp"
 #include "Geometry.hpp"
+#include "PolygonCollider.hpp"
 
 #include <iostream>
 
@@ -67,6 +68,7 @@ class Entity {
     void resolvePendingActions() {
         if (_movementPending && !_collisionDetected) {
             _position = _pendingPosition;
+            _tempCollider.moveTo(_pendingPosition);
         }
 
         _movementPending = false;
@@ -102,4 +104,5 @@ class Entity {
     bool _collisionDetected = false;
 
     std::vector<Hitbox> _hitboxes{};
+    PolygonCollider _tempCollider{};
 };

--- a/src/PolygonCollider.cpp
+++ b/src/PolygonCollider.cpp
@@ -25,9 +25,13 @@ void PolygonCollider::moveTo(const Vector2& desiredPosition)
     // OLD moveTo code:
     // _pendingPosition = desiredPosition;
     // _movementPending = true;
-    
     // Temporary moveTo:
+    auto differenceVector = desiredPosition - _position;
     _position = desiredPosition;
+    for (auto& vertex : vertices) {
+        vertex.x += differenceVector.x;
+        vertex.y += differenceVector.y;
+    }
 }
 
 void PolygonCollider::move(const Vector2& desiredMovement)
@@ -40,8 +44,13 @@ void PolygonCollider::move(const Vector2& desiredMovement)
     _position = _position + desiredMovement;
 }
 
-void PolygonCollider::rotate(const double degreesRotated)
+void PolygonCollider::addVertex(const Vector2& vertex)
 {
+    vertices.emplace_back(vertex);
+}
+
+// void PolygonCollider::rotate(const double degreesRotated)
+// {
     // OLD rotate code:
     // _angle += degreesRotated;
-}
+// }

--- a/src/PolygonCollider.hpp
+++ b/src/PolygonCollider.hpp
@@ -11,11 +11,6 @@
 using namespace orgmath;
 
 class PolygonCollider : Collider {
-  protected:
-    /// Vector of vertices for the polygon.
-    /// TODO: Switch to WorldPos type eventually.
-    std::vector<Vector2>  _vertices{};
-
   public:
     /// Constructor.
     PolygonCollider();
@@ -39,9 +34,20 @@ class PolygonCollider : Collider {
 
     void move(const Vector2& desiredMovement);
 
-    void rotate(const double degreesRotated);
+
+    // TODO: render override will need to be used once other collider types are supported.
+    // void render();
+
+    void addVertex(const Vector2& vertex);
+
+    // TODO: Implement polygon collider rotation.
+    // void rotate(const double degreesRotated);
 
     std::string type = "";
     std::string id = "";
     bool isBlocking;
+
+    /// Vector of vertices for the polygon.
+    /// TODO: Switch to WorldPos type eventually.
+    std::vector<Vector2> vertices{};
 };

--- a/src/TexturedEntity.cpp
+++ b/src/TexturedEntity.cpp
@@ -51,6 +51,12 @@ void TexturedEntity::render(bool debug_worldPosition, bool debug_hitboxes)
         }
     }
 
+    try {
+        displayEngine.drawPolygon(_tempCollider.vertices);
+    } catch(...) {
+        // No valid polygon collider, do nothing for now..
+    }
+
     // Render the entities hitboxes, if requested.
     if (debug_hitboxes) {
         for (const auto& [hitbox, isBlocking] : _hitboxes) {


### PR DESCRIPTION
New collider types supporting arbitrary polygons can be used to check for collisions via the separating axis theorem.